### PR TITLE
Adds /employees and /employees/[id] pages with basic data load

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  experimental: {
+    swcPlugins: [
+      [
+        "next-superjson-plugin",
+        {
+          excluded: [],
+        },
+      ],
+    ],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "luxon": "^3.2.1",
         "next": "13.1.1",
         "next-auth": "^4.18.7",
+        "next-superjson-plugin": "^0.5.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "typescript": "4.9.4"
@@ -581,6 +582,21 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/copy-anything": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.3.tgz",
+      "integrity": "sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==",
+      "peer": true,
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -757,6 +773,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -809,6 +833,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.8.tgz",
+      "integrity": "sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA==",
+      "peer": true,
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/jose": {
@@ -984,6 +1020,18 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-superjson-plugin": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/next-superjson-plugin/-/next-superjson-plugin-0.5.3.tgz",
+      "integrity": "sha512-vHN+96TKEVxKUfcgX40W/w/UJhwaPFcrJTggDDN0JuN7pNvyFXqJwVJCTeiuMUeSFJnwNYcd4mRM5jVlw8GjAA==",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "next": "^13",
+        "superjson": "^1"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -1333,6 +1381,11 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -1445,6 +1498,18 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/superjson": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.1.tgz",
+      "integrity": "sha512-HMTj43zvwW5bD+JCZCvFf4DkZQCmiLTen4C+W1Xogj0SPOpnhxsriogM04QmBVGH5b3kcIIOr6FqQ/aoIDx7TQ==",
+      "peer": true,
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -1921,6 +1986,15 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
+    "copy-anything": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.3.tgz",
+      "integrity": "sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==",
+      "peer": true,
+      "requires": {
+        "is-what": "^4.1.8"
+      }
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2052,6 +2126,14 @@
         "function-bind": "^1.1.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2090,6 +2172,12 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
+    },
+    "is-what": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.8.tgz",
+      "integrity": "sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA==",
+      "peer": true
     },
     "jose": {
       "version": "4.11.2",
@@ -2206,6 +2294,14 @@
         "preact": "^10.6.3",
         "preact-render-to-string": "^5.1.19",
         "uuid": "^8.3.2"
+      }
+    },
+    "next-superjson-plugin": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/next-superjson-plugin/-/next-superjson-plugin-0.5.3.tgz",
+      "integrity": "sha512-vHN+96TKEVxKUfcgX40W/w/UJhwaPFcrJTggDDN0JuN7pNvyFXqJwVJCTeiuMUeSFJnwNYcd4mRM5jVlw8GjAA==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.2"
       }
     },
     "node-releases": {
@@ -2405,6 +2501,11 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -2473,6 +2574,15 @@
       "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
       "requires": {
         "client-only": "0.0.1"
+      }
+    },
+    "superjson": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.1.tgz",
+      "integrity": "sha512-HMTj43zvwW5bD+JCZCvFf4DkZQCmiLTen4C+W1Xogj0SPOpnhxsriogM04QmBVGH5b3kcIIOr6FqQ/aoIDx7TQ==",
+      "peer": true,
+      "requires": {
+        "copy-anything": "^3.0.2"
       }
     },
     "supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "luxon": "^3.2.1",
     "next": "13.1.1",
     "next-auth": "^4.18.7",
+    "next-superjson-plugin": "^0.5.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "4.9.4"

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -3,17 +3,13 @@ import { unstable_getServerSession } from "next-auth/next";
 import { Session } from "next-auth";
 import { authOptions } from "./api/auth/[...nextauth]";
 
-const Hosts: NextPage<{ session: Session }> = ({ session }) => {
+const Dashboard: NextPage<{ session: Session }> = ({ session }) => {
   return (
     <div>
-      {session && (
-        <div className="mx-auto">
-          Session!!!
-        </div>
-      )}
+      {session && <div className="mx-auto">Session!!!</div>}
       {!session && <div>Missing a session</div>}
     </div>
   );
 };
 
-export default Hosts;
+export default Dashboard;

--- a/pages/employees.tsx
+++ b/pages/employees.tsx
@@ -1,0 +1,43 @@
+import { GetServerSideProps, NextPage } from "next";
+import { Employee, PrismaClient } from "@prisma/client";
+import Link from "next/link";
+
+interface Props {
+  employees: Employee[];
+}
+
+const Employees: NextPage<Props> = ({ employees }) => {
+  return (
+    <div>
+      {(!employees || employees.length === 0) && (
+        <div>
+          <p>No employees</p>
+        </div>
+      )}
+
+      {employees &&
+        employees.length > 0 &&
+        employees.map((employee) => {
+          return (
+            <Link href={`/employees/${employee.id}`}>
+              <p>ID: {employee.id}</p>
+            </Link>
+          );
+        })}
+    </div>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const prisma = new PrismaClient();
+
+  const employees: Employee[] = await prisma.employee.findMany();
+
+  return {
+    props: {
+      employees,
+    },
+  };
+};
+
+export default Employees;

--- a/pages/employees/[id].tsx
+++ b/pages/employees/[id].tsx
@@ -1,0 +1,49 @@
+import { GetServerSideProps, NextPage } from "next";
+import { Employee, PrismaClient } from "@prisma/client";
+
+interface Props {
+  employee: Employee;
+}
+
+const Employees: NextPage<Props> = ({ employee }) => {
+  return (
+    <div>
+      {!employee && (
+        <div>
+          <p>No employee found</p>
+        </div>
+      )}
+
+      {employee && (
+        <div>
+          <p>ID: {employee.id}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const employeeId: string = context.params?.id as string;
+  const prisma = new PrismaClient();
+
+  const employee: Employee | null = await prisma.employee.findUnique({
+    where: {
+      id: employeeId,
+    },
+  });
+
+  if (!employee) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      employee: employee,
+    },
+  };
+};
+
+export default Employees;


### PR DESCRIPTION
Adds /employees and /employees/[id] pages, loads the data, and puts the ID on screen.

Added the superjson plugin because next.js can’t json serialize date types automatically, and this shim handles that automatically.