### PR TITLE
Add workaround to payload email

### DIFF
--- a/pages/api/flatfile/create-space.ts
+++ b/pages/api/flatfile/create-space.ts
@@ -121,7 +121,7 @@ export default async function handler(
     body: JSON.stringify(payload),
     headers: headers,
   });
-  
+
   console.log("addGuestToSpaceResponse", addGuestToSpaceResponse);
   
   // TODO: Add guest API is breaking on email unique constraint


### PR DESCRIPTION
This PR contains: 

- Edit to payload for `addGuestToSpaceResponse` to workaround the duplicate email validation in `X` DB.