### PR TITLE
Fix job migration and backfill

### DIFF
--- a/prisma/migrations/20230224223053_add_org_to_jobs/migration.sql
+++ b/prisma/migrations/20230224223053_add_org_to_jobs/migration.sql
@@ -5,14 +5,14 @@
 
 */
 -- AlterTable
-ALTER TABLE "Job" ADD COLUMN     "organizationId" UUID NOT NULL DEFAULT uuid_generate_v4();
+ALTER TABLE "Job" ADD COLUMN     "organizationId" UUID NULL;
 
 UPDATE "Job" 
 SET "organizationId" = "Employee"."organizationId"
 FROM "Employee"
 WHERE "Job"."employeeId" = "Employee"."id";
 
-ALTER TABLE "Job" ALTER COLUMN "organizationId" DROP DEFAULT;
+ALTER TABLE "Job" ALTER COLUMN "organizationId" SET NOT NULL;
 
 -- AddForeignKey
 ALTER TABLE "Job" ADD CONSTRAINT "Job_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
Why this PR?
- Job migration in prod is broken. 

This PR contains:
- Add NOT NULLABLE to column with a default UUID value and then remove default 