### PR TITLE
PROD config workaround - Lookup jobId using jobName instead

### DIFF
--- a/lib/sync-records.ts
+++ b/lib/sync-records.ts
@@ -67,12 +67,14 @@ export const syncWorkbookRecords = async ({
         })) as EmployeeType
       ).id;
 
-      const jobId = (await prismaClient.job.findUnique({
-        where: {
-          slug: values.jobCode.value as string,
-          organization: { id: organizationId },
-        },
-      }))!.id;
+      const jobId = (
+        (await prismaClient.job.findFirst({
+          where: {
+            organizationId,
+            name: values.jobName.value as string,
+          },
+        })) as Job
+      ).id;
 
       let data: Parameters<typeof upsertEmployee>[0] = {
         organizationId,


### PR DESCRIPTION
Why this PR?
- During sheet creation, jobCode is not populating correctly from the config. As a workaround, The job is being looked up using the jobName from the sheet instead

This PR contains
- Edit to jobId variable lookup. Changes the query to lookup using the jobName from the uploaded sheet.