### PR TITLE
Add columns to junction table EmployeeBenefitPlan

### DIFF
--- a/lib/employee.ts
+++ b/lib/employee.ts
@@ -34,6 +34,9 @@ export const upsertEmployee = async ({
   benefitPlans: {
     create: [
       {
+        currentlyEnrolled: boolean;
+        coverageBeginDate: Date;
+        employeeContribution: number;
         benefitPlan: {
           connect: {
             id: string;

--- a/lib/seeds/main.ts
+++ b/lib/seeds/main.ts
@@ -789,6 +789,9 @@ export const upsertEmployees = async (organizationId: string) => {
     benefitPlans: {
       create: [
         {
+          currentlyEnrolled: true,
+          coverageBeginDate: DateTime.now().toJSDate(),
+          employeeContribution: 543.21,
           benefitPlan: {
             connect: {
               id: benefitPlanRecord.id,

--- a/lib/sync-records.ts
+++ b/lib/sync-records.ts
@@ -138,6 +138,9 @@ export const syncWorkbookRecords = async ({
         benefitPlans: {
           create: [
             {
+              currentlyEnrolled: true,
+              coverageBeginDate: DateTime.now().toJSDate(),
+              employeeContribution: 100.01,
               benefitPlan: {
                 connect: {
                   id: benefitPlan.id,

--- a/prisma/migrations/20230321215237_add_columns_to_employees_benefit_plan_junction_table/migration.sql
+++ b/prisma/migrations/20230321215237_add_columns_to_employees_benefit_plan_junction_table/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "EmployeeBenefitPlan" ADD COLUMN     "coverageBeginDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "currentlyEnrolled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "employeeContribution" DOUBLE PRECISION NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -171,6 +171,10 @@ model EmployeeBenefitPlan {
   benefitPlanId String @db.Uuid
   benefitPlan BenefitPlan @relation(fields: [benefitPlanId], references: [id])
 
+  currentlyEnrolled Boolean @default(false)
+  coverageBeginDate DateTime @default(now())
+  employeeContribution Float @default(0)
+
   @@id([employeeId, benefitPlanId])
 }
 


### PR DESCRIPTION
Why this PR?
- Update schema for EmployeeBenefitPlan to add new columns

This PR contains: 
- Update schema and add migration
- Update seed and sync flows to adapt these columns