### PR TITLE
Guestlink removed from API. Edited to sharedlink

### DIFF
--- a/lib/flatfile.ts
+++ b/lib/flatfile.ts
@@ -238,7 +238,7 @@ export const createSpace = async ({
       theme: theme(focusBgColor, backgroundColor),
     },
     actions: [],
-    guestAuthentication: ["shared_link"],
+    guestAuthentication: ["shared_link", "magic_link"],
   };
 
   const spaceResponse = await fetch(`${BASE_PATH}/spaces`, {

--- a/lib/flatfile.ts
+++ b/lib/flatfile.ts
@@ -238,6 +238,7 @@ export const createSpace = async ({
       theme: theme(focusBgColor, backgroundColor),
     },
     actions: [],
+    guestAuthentication: ["shared_link"],
   };
 
   const spaceResponse = await fetch(`${BASE_PATH}/spaces`, {


### PR DESCRIPTION
Why this PR:
- Guestlink was removed from the API. Grabbing the guestlink in another way

This PR contains:
- Set guest authentication to sharedLink to have the space return a guestlink