### PR TITLE
Remove danger colors and add comments

### DIFF
--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -5,10 +5,7 @@ export function theme(
   return {
     root: {
       primaryColor: backgroundColor,
-      dangerColor: "#F44336",
       warningColor: "#FF9800",
-      dangerLightColor: "#F44336",
-      dangerLessLightColor: "#F44336",
     },
     sidebar: {
       logo: `https://images.ctfassets.net/e8fqfbar73se/4c9ouGKgET1qfA4uxp4qLZ/e3f1a8b31be67a798c1e49880581fd3d/white-logo-w-padding.png`,

--- a/pages/dynamic-portal.tsx
+++ b/pages/dynamic-portal.tsx
@@ -251,6 +251,8 @@ const DynamicTemplates: NextPageWithLayout<Props> = ({
     publishableKey,
     environmentId: environmentToken,
     name: "Dynamic Portal",
+    // IMPORTANT NOTE: If there are any changes to the theme or document set below,
+    // you must update the theme and document in the adjoining index.ts file in hcm-show-config as well
     themeConfig: theme("#E28170", "#D64B32"),
     document: document,
     workbook: filterConfig({

--- a/pages/embedded-portal.tsx
+++ b/pages/embedded-portal.tsx
@@ -81,6 +81,8 @@ const EmbeddedPortal: NextPageWithLayout<Props> = ({
     publishableKey,
     environmentId: environmentToken,
     name: "Embedded Portal",
+    // IMPORTANT NOTE: If there are any changes to the theme or document set below,
+    // you must update the theme and document in the adjoining index.ts file in hcm-show-config as well
     themeConfig: theme("#4DCA94", "#32A673"),
     document: document,
     workbook: workbookConfig,


### PR DESCRIPTION
Why this PR?
- The danger colors are having a default set to them, making the already set colors unnecessary

This PR contains: 
- Removal of colors set for "danger" overrides
- Add comments on embedded and dynamic props for useSpace