### PR TITLE
Edit dates to stay utc during conversion

### DIFF
--- a/lib/action.ts
+++ b/lib/action.ts
@@ -77,8 +77,12 @@ export const fileFeedEventFromAction = (
 
   const date =
     typeof action.createdAt === "string"
-      ? DateTime.fromISO(action.createdAt)
-      : DateTime.fromJSDate(action.createdAt);
+      ? DateTime.fromISO(action.createdAt, {
+          zone: "utc",
+        })
+      : DateTime.fromJSDate(action.createdAt, {
+          zone: "utc",
+        });
 
   return {
     topic: metadata.topic,

--- a/pages/employees.tsx
+++ b/pages/employees.tsx
@@ -180,9 +180,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       employeeId: employee.employeeId,
       firstName: employee.firstName,
       lastName: employee.lastName,
-      hireDate: DateTime.fromJSDate(employee.hireDate).toFormat("MM/dd/yyyy"),
+      hireDate: DateTime.fromJSDate(employee.hireDate, {
+        zone: "utc",
+      }).toFormat("MM-dd-yyyy"),
       endEmploymentDate: employee.endEmploymentDate
-        ? DateTime.fromJSDate(employee.endEmploymentDate).toFormat("MM/dd/yyyy")
+        ? DateTime.fromJSDate(employee.endEmploymentDate, {
+            zone: "utc",
+          }).toFormat("MM/dd/yyyy")
         : null,
       positionTitle: employee.positionTitle,
       scheduledWeeklyHours: employee.scheduledWeeklyHours,

--- a/pages/employees/[id].tsx
+++ b/pages/employees/[id].tsx
@@ -111,9 +111,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     employeeId: dbEmployee.employeeId,
     firstName: dbEmployee.firstName,
     lastName: dbEmployee.lastName,
-    hireDate: DateTime.fromJSDate(dbEmployee.hireDate).toFormat("MM/dd/yyyy"),
+    hireDate: DateTime.fromJSDate(dbEmployee.hireDate, {
+      zone: "utc",
+    }).toFormat("MM/dd/yyyy"),
     endEmploymentDate: dbEmployee.endEmploymentDate
-      ? DateTime.fromJSDate(dbEmployee.endEmploymentDate).toFormat("MM/dd/yyyy")
+      ? DateTime.fromJSDate(dbEmployee.endEmploymentDate, {
+          zone: "utc",
+        }).toFormat("MM/dd/yyyy")
       : null,
     positionTitle: dbEmployee.positionTitle,
     scheduledWeeklyHours: dbEmployee.scheduledWeeklyHours,

--- a/pages/jobs.tsx
+++ b/pages/jobs.tsx
@@ -117,9 +117,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       id: job.id,
       name: job.name,
       department: job.department,
-      effectiveDate: DateTime.fromJSDate(job.effectiveDate).toFormat(
-        "MM/dd/yyyy"
-      ),
+      effectiveDate: DateTime.fromJSDate(job.effectiveDate, {
+        zone: "utc",
+      }).toFormat("MM-dd-yyyy"),
       isInactive: job.isInactive,
     };
   });

--- a/pages/jobs/[id].tsx
+++ b/pages/jobs/[id].tsx
@@ -88,9 +88,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     id: dbJob.id,
     name: dbJob.name,
     department: dbJob.department,
-    effectiveDate: DateTime.fromJSDate(dbJob.effectiveDate).toFormat(
-      "MM/dd/yyyy"
-    ),
+    effectiveDate: DateTime.fromJSDate(dbJob.effectiveDate, {
+      zone: "utc",
+    }).toFormat("MM/dd/yyyy"),
     isInactive: dbJob.isInactive,
   };
 


### PR DESCRIPTION
Why this PR?
- Existing dates were being converted from utc to another timezone

This PR contains: 
- edited date conversion to stay as utc after conversion